### PR TITLE
filter out the empty-string category in graph

### DIFF
--- a/client/src/Components/Graph/Categories.js
+++ b/client/src/Components/Graph/Categories.js
@@ -27,7 +27,7 @@ const Categories = (props) => {
       const categories = [
         ...new Set(
           lemmataList.flatMap((lemma) =>
-            lemma.meanings.map((meaning) => meaning.category)
+            lemma.meanings.map((meaning) => meaning.category).filter(Boolean) // remove null and empty-string categories
           )
         ),
       ];
@@ -52,7 +52,7 @@ const Categories = (props) => {
 
       const edges = lemmataList
         .flatMap((lemma) =>
-          lemma.meanings.map((meaning) => ({
+          lemma.meanings.filter(meaning => Boolean(meaning.category)).map((meaning) => ({
             from: lemma.lemmaId,
             to: "category:" + meaning.category,
             id: v4(),


### PR DESCRIPTION
Currently we are still having the problem that there are two empty-string categories appearing in the categories graph. One is due to meanings like this (with an empty category):

![Screenshot 2025-04-28 at 10 16 57](https://github.com/user-attachments/assets/4abebfac-d715-40a9-95a2-6015b253b236)

The other one is due to meanings like this:

![Screenshot 2025-04-28 at 10 17 45](https://github.com/user-attachments/assets/96cc5a10-b3c7-4281-bca9-aaf66189d035)

The changes I made should address both of these cases.
However, I could not test them as I could not get Docker installed as of yet.
@christiancasey Could you test it before merging?